### PR TITLE
Update github action pipelines and go release

### DIFF
--- a/.github/workflows/depscheck.yaml
+++ b/.github/workflows/depscheck.yaml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: true
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
         with:
-         go-version: '1.19'
+          go-version-file: 'go.mod'
       - run: make depscheck

--- a/.github/workflows/golint.yaml
+++ b/.github/workflows/golint.yaml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
-      - uses: golangci/golangci-lint-action@v2
+      - uses: golangci/golangci-lint-action@v3
         with:
-          version: 'v1.51.1'
-          args: -v
+          version: 'v1.54'

--- a/.github/workflows/golint.yaml
+++ b/.github/workflows/golint.yaml
@@ -14,10 +14,10 @@ jobs:
     strategy:
       fail-fast: true
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version-file: 'go.mod'
       - uses: golangci/golangci-lint-action@v2
         with:
           version: 'v1.51.1'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,14 +11,14 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       -
         name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.17
+          go-version-file: 'go.mod'
       -
         name: Import GPG key
         id: import_gpg
@@ -28,10 +28,10 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.github/workflows/thirty-two-bit.yaml
+++ b/.github/workflows/thirty-two-bit.yaml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: true
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version-file: 'go.mod'
       - run: GOARCH=386 GOOS=linux go build -o 32bitbuild .

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -14,10 +14,10 @@ jobs:
     strategy:
       fail-fast: true
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version-file: 'go.mod'
       - run: make test
         env:
           GITHUB_ACTIONS_STAGE: "UNIT_TESTS"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/*
 .idea
 */.DS_Store
+dist/*

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,21 +16,21 @@ builds:
     ldflags:
       - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
     goos:
-      - freebsd
       - windows
       - linux
       - darwin
     goarch:
-      - amd64
       - '386'
-      - arm
+      - amd64
       - arm64
     ignore:
       - goos: darwin
         goarch: '386'
+      - goos: windows
+        goarch: '386'
     binary: '{{ .ProjectName }}'
 archives:
-  - format: zip
+  - format: tar.gz
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
@@ -48,7 +48,6 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 release:
-  # If you want to manually examine the release before its live, uncomment this line:
-  draft: true
+  draft: false
 changelog:
-  skip: true
+  skip: false

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ms-henglu/pal
 
-go 1.19
+go 1.21
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -3,12 +3,16 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1/go.mod h1:bjGvMhVMb+EEm3VRNQ
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 h1:sXr+ck84g/ZlZUOZiNELInmMgOsuGwdjjVkEIde0OtY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0/go.mod h1:okt5dMMTOFjX/aovMlrjvvXoPMBVSPzk9185BT0+eZM=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gertd/go-pluralize v0.2.1 h1:M3uASbVjMnTsPb0PNqg+E/24Vwigyo/tvyMTtAlLgiA=
 github.com/gertd/go-pluralize v0.2.1/go.mod h1:rbYaKDbsXxmRfr8uygAEKhOWsjyrrqrkHVpZvoOp8zk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=
 golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
 golang.org/x/text v0.8.0 h1:57P1ETyNKtuIjB4SRd15iJxuhj8Gc416Y78H3qgMh68=
 golang.org/x/text v0.8.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Hi,

what I changed:
- All github actions (plugin versions updated)
- Goreleaser configuration changed
- Go version updated to 1.21


Goreleaser config changes:
- removed 32bit arm
- build 32bin only for linux
- change archive format to tar.gz
- upload build tar.gz binary files to gh release