### PR TITLE
Fix goreleaser-action version pin for v2 config

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,9 +28,9 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          version: 'v2.12.2'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The v0.6.0 release run failed with:

```
error=only configurations files on version: 1 are supported, yours is version: 2, please update your configuration
```

`goreleaser-action@v5` with `version: latest` locks to the latest GoReleaser v1.x release for backward compatibility, but `.goreleaser.yml` uses schema `version: 2`. Pins `goreleaser-action@v6` with an explicit GoReleaser `v2.12.2`, matching the version already validated locally (`goreleaser check` and a snapshot build both passed).