### PR TITLE
Grant contents:write permission to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       -
         name: Checkout


### PR DESCRIPTION
The re-run after #17 progressed all the way through build/archive/checksum/sign, but failed publishing with:

```
scm releases: failed to publish artifacts: could not release: POST https://api.github.com/repos/ms-henglu/pal/releases: 403 Resource not accessible by integration
```

The default `GITHUB_TOKEN` didn't have write access to create the release. Adds an explicit `permissions: contents: write` at the job level so GoReleaser can create the GitHub Release and upload assets.